### PR TITLE
Fix wally syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following to your `wally.toml`:
 
 ```
 [dependencies]
-ContextControls = "vocksel/context-controls@v1.0.1
+ContextControls = "vocksel/context-controls@1.0.1
 ```
 
 ### Model File


### PR DESCRIPTION
Super tiny fix. Had a `v` in the dependency path which is incorrect